### PR TITLE
Feature: Deploy to FTP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
 
   coverage:
     name: Coverage Analysis
+    if: github.ref != 'refs/heads/feature/ftp-deploy'
     needs: buildAndTest
     runs-on: ubuntu-latest
     steps:
@@ -109,20 +110,43 @@ jobs:
       #     publish_dir: dist
 
       - name: Find and Replace Basename
-        id: find_replace_basename
+        id: find_replace_basename1
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "/portfolio-redux"
           replace: ""
           regex: false
-          include: "**/index*.!(map)"
+          include: "**index**.@(html|js|css)"
+
+      - name: Find and Replace Basename
+        id: find_replace_basename2
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "/portfolio-redux"
+          replace: ""
+          regex: false
+          include: "**/**index**.*"
+
+      - name: Find and Replace Basename
+        id: find_replace_basename3
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "/portfolio-redux"
+          replace: ""
+          regex: false
+          include: "**/**index**.@(html|js|css)"
+
 
       - name: Modified Files
         run:
           echo "find_replace_datetime:"
-          echo "${{ steps.find_replace_datetime.outputs.modifiedFiles }}"
-          echo "find_replace_basename:"
-          echo "${{ steps.find_replace_basename.outputs.modifiedFiles }}"
+          echo "${{ steps.find_replace_datetime.outputs.modifiedFiles }}\n"
+          echo "find_replace_basename1:"
+          echo "${{ steps.find_replace_basename1.outputs.modifiedFiles }}\n"
+          echo "find_replace_basename2:"
+          echo "${{ steps.find_replace_basename2.outputs.modifiedFiles }}\n"
+          echo "find_replace_basename3:"
+          echo "${{ steps.find_replace_basename3.outputs.modifiedFiles }}\n"
 
       - name: 🚀 FTP Deploy to Bluehost
         uses: SamKirkland/FTP-Deploy-Action@v4.3.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           find: "/portfolio-redux"
           replace: ""
           regex: false
-          include: "**index**.@(html|js|css)"
+          include: "**/**index**.!(map)"
 
       - name: Find and Replace Basename
         id: find_replace_basename2
@@ -125,7 +125,7 @@ jobs:
           find: "/portfolio-redux"
           replace: ""
           regex: false
-          include: "**/**index**.*"
+          include: "**/**index**.(html|js|css)"
 
       - name: Find and Replace Basename
         id: find_replace_basename3
@@ -134,7 +134,7 @@ jobs:
           find: "/portfolio-redux"
           replace: ""
           regex: false
-          include: "**/**index**.@(html|js|css)"
+          include: "**/**index**.*(html|js|css)"
 
 
       - name: Modified Files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,94 +70,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  deployFTP:
-    name: Deploy to FTP
-    # Deploy only for test branch
-    if: github.ref == 'refs/heads/feature/ftp-deploy'
-    needs: buildAndTest
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    environment:
-      name: prod
-      url: https://dcpesses.github.io/portfolio-redux/ # <- Change to your site url
-    steps:
-      # Download dist artifacts
-      - uses: actions/download-artifact@v5
-        with:
-          name: dist
-          path: dist/
-
-      - name: Set current date as env variable
-        run: echo "NOW=$(TZ=America/Los_Angeles date +'%F %T %Z')" >> $GITHUB_ENV
-
-      # - name: Debug current date
-      #   run: echo "${{ env.NOW }}" # Gives "2024-02-16 16:53:32 PST" modifiedFiles
-
-      - name: Find and Replace
-        id: find_replace_datetime
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "DATE_TIME"
-          replace: "${{ env.NOW }}"
-          regex: false
-          include: "**index.html"
-
-      # - name: 🚀 Deploy to GitHub Pages
-      #   uses: peaceiris/actions-gh-pages@v4.0.0
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     publish_dir: dist
-
-      - name: Find and Replace Basename 1
-        id: find_replace_basename1
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "/portfolio-redux"
-          replace: ""
-          regex: false
-          include: "**/*(index*.{html,js,css}|site.webmanifest)"
-
-      - name: Find and Replace Basename 2
-        id: find_replace_basename2
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "/portfolio-redux"
-          replace: ""
-          regex: false
-          include: "**/(index*.{html,js,css}|site.webmanifest)"
-
-
-      - name: Find and Replace Basename 3
-        id: find_replace_basename3
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "/portfolio-redux"
-          replace: ""
-          regex: false
-          include: "**(index*.{html,js,css}|site.webmanifest)"
-
-
-      - name: Modified Files
-        run:
-          echo "datetime:"
-          echo "${{ steps.find_replace_datetime.outputs.modifiedFiles }} |"
-          echo "basename1:"
-          echo "${{ steps.find_replace_basename1.outputs.modifiedFiles }} |"
-          echo "basename2:"
-          echo "${{ steps.find_replace_basename2.outputs.modifiedFiles }} |"
-          echo "basename3:"
-          echo "${{ steps.find_replace_basename3.outputs.modifiedFiles }} |"
-
-      - name: 🚀 FTP Deploy to Bluehost
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
-        with:
-          server: ${{ secrets.FTPDEPLOY_SERVER }}
-          username: ${{ secrets.FTPDEPLOY_USERNAME }}
-          password: ${{ secrets.FTPDEPLOY_PASSWORD }}
-          protocol: ftps
-          local-dir: ./dist/
-
   deploy:
     name: Deploy
     # Deploy only for main branch
@@ -184,7 +96,7 @@ jobs:
       # - name: Debug current date
       #   run: echo "${{ env.NOW }}" # Gives "2024-02-16 16:53:32 PST"
 
-      - name: Find and Replace
+      - name: Find and Replace Date & Time
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "DATE_TIME"
@@ -197,3 +109,30 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: dist
+
+      - name: Find and Replace Basename
+        id: find_replace_basename
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "/portfolio-redux"
+          replace: ""
+          regex: false
+          include: "**index*.{html,js,css}"
+
+      - name: Find and Replace Basename (Webmanifest)
+        id: find_replace_basename_webmanifest
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "/portfolio-redux"
+          replace: ""
+          regex: false
+          include: "**site.webmanifest"
+
+      - name: 🚀 FTP Deploy to Bluehost
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
+        with:
+          server: ${{ secrets.FTPDEPLOY_SERVER }}
+          username: ${{ secrets.FTPDEPLOY_USERNAME }}
+          password: ${{ secrets.FTPDEPLOY_PASSWORD }}
+          protocol: ftps
+          local-dir: ./dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
 
   coverage:
     name: Coverage Analysis
-    if: github.ref != 'refs/heads/feature/ftp-deploy'
     needs: buildAndTest
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,27 @@ jobs:
       - name: 🧪 Test
         run: npm run test:ci
 
+      ## START FTP DEPLOY TEST
+
+      - name: Find and Replace Basename
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "/portfolio-redux"
+          replace: ""
+          regex: false
+          include: "**/index*.!(map)"
+
+      - name: 🚀 FTP Deploy to Bluehost
+        uses: samkirkland/ftp-deploy-action@v4.3.6
+        with:
+          server: ${{ secrets.FTPDEPLOY_SERVER }}
+          username: ${{ secrets.FTPDEPLOY_USERNAME }}
+          password: ${{ secrets.FTPDEPLOY_PASSWORD }}
+          protocol: ftps
+          local-dir: ./dist/
+
+      ## END FTP DEPLOY TEST
+
       # Upload dist artifacts
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           find: "/portfolio-redux"
           replace: ""
           regex: false
-          include: "**/**index**.!(map)"
+          include: "**index*.{html,js,css}"
 
       - name: Find and Replace Basename
         id: find_replace_basename2
@@ -125,7 +125,8 @@ jobs:
           find: "/portfolio-redux"
           replace: ""
           regex: false
-          include: "**/**index**.(html|js|css)"
+          include: "**/index*.{html,js,css}"
+
 
       - name: Find and Replace Basename
         id: find_replace_basename3
@@ -134,19 +135,19 @@ jobs:
           find: "/portfolio-redux"
           replace: ""
           regex: false
-          include: "**/**index**.*(html|js|css)"
+          include: "**/index*.*{html,js,css}"
 
 
       - name: Modified Files
         run:
-          echo "find_replace_datetime:"
-          echo "${{ steps.find_replace_datetime.outputs.modifiedFiles }}\n"
-          echo "find_replace_basename1:"
-          echo "${{ steps.find_replace_basename1.outputs.modifiedFiles }}\n"
-          echo "find_replace_basename2:"
-          echo "${{ steps.find_replace_basename2.outputs.modifiedFiles }}\n"
-          echo "find_replace_basename3:"
-          echo "${{ steps.find_replace_basename3.outputs.modifiedFiles }}\n"
+          echo "datetime:"
+          echo "${{ steps.find_replace_datetime.outputs.modifiedFiles }} \r\n"
+          echo "basename1:"
+          echo "${{ steps.find_replace_basename1.outputs.modifiedFiles }} \r\n"
+          echo "basename2:"
+          echo "${{ steps.find_replace_basename2.outputs.modifiedFiles }} \r\n"
+          echo "basename3:"
+          echo "${{ steps.find_replace_basename3.outputs.modifiedFiles }} \r\n"
 
       - name: 🚀 FTP Deploy to Bluehost
         uses: SamKirkland/FTP-Deploy-Action@v4.3.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,45 +109,45 @@ jobs:
       #     github_token: ${{ secrets.GITHUB_TOKEN }}
       #     publish_dir: dist
 
-      - name: Find and Replace Basename
+      - name: Find and Replace Basename 1
         id: find_replace_basename1
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "/portfolio-redux"
           replace: ""
           regex: false
-          include: "**index*.{html,js,css}"
+          include: "**/*(index*.{html,js,css}|site.webmanifest)"
 
-      - name: Find and Replace Basename
+      - name: Find and Replace Basename 2
         id: find_replace_basename2
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "/portfolio-redux"
           replace: ""
           regex: false
-          include: "**/index*.{html,js,css}"
+          include: "**/(index*.{html,js,css}|site.webmanifest)"
 
 
-      - name: Find and Replace Basename
+      - name: Find and Replace Basename 3
         id: find_replace_basename3
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "/portfolio-redux"
           replace: ""
           regex: false
-          include: "**/index*.*{html,js,css}"
+          include: "**(index*.{html,js,css}|site.webmanifest)"
 
 
       - name: Modified Files
         run:
           echo "datetime:"
-          echo "${{ steps.find_replace_datetime.outputs.modifiedFiles }} \r\n"
+          echo "${{ steps.find_replace_datetime.outputs.modifiedFiles }} |"
           echo "basename1:"
-          echo "${{ steps.find_replace_basename1.outputs.modifiedFiles }} \r\n"
+          echo "${{ steps.find_replace_basename1.outputs.modifiedFiles }} |"
           echo "basename2:"
-          echo "${{ steps.find_replace_basename2.outputs.modifiedFiles }} \r\n"
+          echo "${{ steps.find_replace_basename2.outputs.modifiedFiles }} |"
           echo "basename3:"
-          echo "${{ steps.find_replace_basename3.outputs.modifiedFiles }} \r\n"
+          echo "${{ steps.find_replace_basename3.outputs.modifiedFiles }} |"
 
       - name: 🚀 FTP Deploy to Bluehost
         uses: SamKirkland/FTP-Deploy-Action@v4.3.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,27 +39,6 @@ jobs:
       - name: 🧪 Test
         run: npm run test:ci
 
-      ## START FTP DEPLOY TEST
-
-      - name: Find and Replace Basename
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "/portfolio-redux"
-          replace: ""
-          regex: false
-          include: "**/index*.!(map)"
-
-      - name: 🚀 FTP Deploy to Bluehost
-        uses: samkirkland/ftp-deploy-action@v4.3.6
-        with:
-          server: ${{ secrets.FTPDEPLOY_SERVER }}
-          username: ${{ secrets.FTPDEPLOY_USERNAME }}
-          password: ${{ secrets.FTPDEPLOY_PASSWORD }}
-          protocol: ftps
-          local-dir: ./dist/
-
-      ## END FTP DEPLOY TEST
-
       # Upload dist artifacts
       - uses: actions/upload-artifact@v4
         with:
@@ -89,6 +68,70 @@ jobs:
         uses: codecov/codecov-action@v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  deployFTP:
+    name: Deploy to FTP
+    # Deploy only for test branch
+    if: github.ref == 'refs/heads/feature/ftp-deploy'
+    needs: buildAndTest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    environment:
+      name: prod
+      url: https://dcpesses.github.io/portfolio-redux/ # <- Change to your site url
+    steps:
+      # Download dist artifacts
+      - uses: actions/download-artifact@v5
+        with:
+          name: dist
+          path: dist/
+
+      - name: Set current date as env variable
+        run: echo "NOW=$(TZ=America/Los_Angeles date +'%F %T %Z')" >> $GITHUB_ENV
+
+      # - name: Debug current date
+      #   run: echo "${{ env.NOW }}" # Gives "2024-02-16 16:53:32 PST" modifiedFiles
+
+      - name: Find and Replace
+        id: find_replace_datetime
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "DATE_TIME"
+          replace: "${{ env.NOW }}"
+          regex: false
+          include: "**index.html"
+
+      # - name: 🚀 Deploy to GitHub Pages
+      #   uses: peaceiris/actions-gh-pages@v4.0.0
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     publish_dir: dist
+
+      - name: Find and Replace Basename
+        id: find_replace_basename
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "/portfolio-redux"
+          replace: ""
+          regex: false
+          include: "**/index*.!(map)"
+
+      - name: Modified Files
+        run:
+          echo "find_replace_datetime:"
+          echo "${{ steps.find_replace_datetime.outputs.modifiedFiles }}"
+          echo "find_replace_basename:"
+          echo "${{ steps.find_replace_basename.outputs.modifiedFiles }}"
+
+      - name: 🚀 FTP Deploy to Bluehost
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.6
+        with:
+          server: ${{ secrets.FTPDEPLOY_SERVER }}
+          username: ${{ secrets.FTPDEPLOY_USERNAME }}
+          password: ${{ secrets.FTPDEPLOY_PASSWORD }}
+          protocol: ftps
+          local-dir: ./dist/
 
   deploy:
     name: Deploy


### PR DESCRIPTION
Updated deployment script to perform the following jobs after deploying to Github Pages:

- Removes all instances of the project's basename (aka '/portfolio-redux') from build files
- Uploads build files to ftp server specified via repository secrets
  - Uses `FTPDEPLOY_SERVER`, `FTPDEPLOY_USERNAME`, and `FTPDEPLOY_PASSWORD`